### PR TITLE
fix: typo in documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Welcome to the public issue tracker for Mergify.
 This is a place for users of [Mergify](https://mergify.com), to [report bugs](https://github.com/Mergifyio/mergify/issues/new),
 create feature requests, [comment and upvote on community-led ideas](https://github.com/Mergifyio/mergify/discussions).
 
-You can learn more about the product on our [website](https://mergify.com) or by browsing the [documentation](https://docs.mergify.com>).
+You can learn more about the product on our [website](https://mergify.com) or by browsing the [documentation](https://docs.mergify.com).


### PR DESCRIPTION
Fixes #5078
